### PR TITLE
let return undef values (-1) for undef case

### DIFF
--- a/src/alinea/caribu/caribu.py
+++ b/src/alinea/caribu/caribu.py
@@ -165,8 +165,11 @@ def get_incident(eabs, materials):
     if len(eabs) != len(materials):
         raise ValueError("The number of caribu outputs doesn't match the number of inputs")
     alpha = (_absorptance(m) for m in materials)
-
-    return [float(e) / a if a != 0 else e for e, a in zip(eabs, alpha)]
+    ei = [ -1.0 if e == -1
+           else float(e) / a if a != 0
+           else e
+           for e, a in zip(eabs, alpha) ]
+    return ei
 
 
 def write_scene(triangles, materials, canfile, optfile):

--- a/src/cpp/Canestra/src/radioxity.cpp
+++ b/src/cpp/Canestra/src/radioxity.cpp
@@ -609,8 +609,9 @@ int main(int argc,char **argv){
 	    
 	      Eabs[ia]=-1;
 	      Ei[i-1]=Ei[i]=-1;
-	      if(r0==t1)
-		Eabs[ia]=B[0]->ve[i-1]*(1/r0-1)-B[0]->ve[i];
+	     /* CF 2025: this fall-back value differs from a compiler to another : keep -1 in this case */
+	    /*  if(r0==t1)
+		Eabs[ia]=B[0]->ve[i-1]*(1/r0-1)-B[0]->ve[i];*/
 	    }
 	    else{
 	      D0= B[0]->ve[i-1]*r1 - B[0]->ve[i]*t1;

--- a/test/test_triangle_faces.py
+++ b/test/test_triangle_faces.py
@@ -13,8 +13,8 @@ def test_unresolved_faces():
     materials = [(0.05, 0.05)]
     res = raycasting(triangles, materials, lights)
     assert_almost_equal(res['area'][0], 1, 3)
-    assert_almost_equal(res['Eabs'][0], 90, 0)
-    assert_almost_equal(res['Ei'][0], 100, 0)
+    assert_almost_equal(res['Eabs'][0], -1, 0)
+    assert_almost_equal(res['Ei'][0], -1, 0)
     assert_almost_equal(res['Ei_sup'][0], -1, 0)
     assert_almost_equal(res['Ei_inf'][0], -1, 0)
 
@@ -22,8 +22,8 @@ def test_unresolved_faces():
     materials = [(0.05, 0.01, 0.01, 0.05)]
     res = raycasting(triangles, materials, lights)
     assert_almost_equal(res['area'][0], 1, 3)
-    assert_almost_equal(res['Eabs'][0], 94, 0)
-    assert_almost_equal(res['Ei'][0], 100, 0)
+    assert_almost_equal(res['Eabs'][0], -1, 0)
+    assert_almost_equal(res['Ei'][0], -1, 0)
     assert_almost_equal(res['Ei_sup'][0], -1, 0)
     assert_almost_equal(res['Ei_inf'][0], -1, 0)
 


### PR DESCRIPTION
let caribu return -1 when reflectance=transmitance, or when cross product is zero 